### PR TITLE
pp friends - friendEvents

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -63,6 +63,7 @@ export const ApplicationViews = () => {
         </Route>
       </TaskProvider>
       
+      <FriendsProvider>
       <UserEventsProvider>
       <EventsProvider>
         <Route exact path="/events">
@@ -78,6 +79,7 @@ export const ApplicationViews = () => {
         </Route>
       </EventsProvider>
       </UserEventsProvider>
+      </FriendsProvider>
     </>
   )
 }

--- a/src/components/events /Events.css
+++ b/src/components/events /Events.css
@@ -1,0 +1,47 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  text-decoration: none;
+  list-style: none;
+  overflow-wrap: break-word;
+
+  /* border: 1px solid red; */
+}
+
+.event {
+  background: rgba(150, 150, 150, 0.8);
+  padding: 0.5em;
+  width: 30%;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  margin-bottom: 20px;
+  border-bottom: 5px dashed black;
+}
+
+.btn--container {
+  display: flex;
+  justify-content: space-around;
+}
+
+.btn--link,
+.btn--delete {
+  padding: 1em;
+  border-radius: 10px;
+  display: block;
+  width: 40%;
+}
+
+.btn--link {
+  background: #343a40;
+}
+
+.btn--delete {
+  background: pink;
+}

--- a/src/components/events /EventsCard.js
+++ b/src/components/events /EventsCard.js
@@ -1,31 +1,22 @@
 import React, { useEffect, useContext } from "react"
 import { useHistory } from "react-router-dom"
-import { UserEventsContext } from "./UserEventsProvider"
 
 export const EventsCard = (props) => {
-  const {userEvents, getUserEvents} = useContext(UserEventsContext)
-
   const history = useHistory()
-
-  useEffect(() => {
-    getUserEvents()
-  }, [])
+  const userId = parseInt(sessionStorage.nutshell_user)
 
   const showEditButton = (eventObj) => {
-    const currentEvent = userEvents.find(event => event.eventId === eventObj.id)
-    if (currentEvent !== undefined){
-      if (currentEvent.userId === parseInt(sessionStorage.nutshell_user) && currentEvent.creator === true){
-        return <button className="event__editButton" onClick={() => {history.push(`/events/edit/${currentEvent.id}`)}}>Edit Event</button>
-      }
+    if (eventObj.userId === userId && eventObj.creator === true){
+      return <button className="event__editButton" onClick={() => {history.push(`/events/edit/${eventObj.id}`)}}>Edit Event</button>
     }
   }
 
   return (
     <>
-    <div className="event">
-      <div className="event__name">Event Name: {props.event.name}</div>
-      <div className="event__location">Location: {props.event.location}</div>
-      <div className="event__date">Date: {props.event.date}</div>
+    <div className="event" style={props.event.userId === userId ? {} : {background: "cornsilk"}}>
+      <div className="event__name">{props.event.userId === userId ? `Event Name: ${props.event.name}` : <i>Event Name: {props.event.name}</i>}</div>
+      <div className="event__location">{props.event.userId === userId ? `Location: ${props.event.location}` : <i>Location: {props.event.location}</i>}</div>
+      <div className="event__date">{props.event.userId === userId ? `Date: ${props.event.date}` : <i>Date: {props.event.date}</i>}</div>
       {
         showEditButton(props.event)
       }

--- a/src/components/events /EventsList.js
+++ b/src/components/events /EventsList.js
@@ -2,26 +2,51 @@ import React, { useContext, useEffect } from "react"
 import { Link } from "react-router-dom"
 import { EventsCard } from "./EventsCard"
 import { EventsContext } from "./EventsProvider"
+import "./Events.css"
+import { FriendsContext } from "../friends/FriendsProvider"
+import { UserEventsContext } from "./UserEventsProvider"
 
 export const EventsList = () => {
   const {events, getEvents} = useContext(EventsContext)
+  const {friends, getFriends} = useContext(FriendsContext)
+  const {userEvents, getUserEvents} = useContext(UserEventsContext)
+
+  const userId = parseInt(sessionStorage.nutshell_user)
 
   useEffect(() => {
-    getEvents()
+    getFriends()
+    .then(getEvents)
+    .then(getUserEvents)
   }, [])
 
-  return (
-    <>
-    <Link to="/events/create">
-    <button className="btn--addEvent">Add Event</button>
-    </Link>
-    <div className="events">
-      {
-        events.map(event => {
-          return <EventsCard key={event.id} event={event} />
-        })
-      }
-    </div>
-    </>
-  )
+  const filteredFriends = friends.filter(friend => friend.currentUserId === userId)
+  let filteredEvents = filteredFriends.map(friend => {
+    return userEvents.filter(ue => ue.userId === friend.userId)
+  })
+  filteredEvents.push(userEvents.filter(ue => ue.userId === userId))
+  filteredEvents = filteredEvents.flat().map(ue => {
+    const matchingEvent = events.find(event => event.id === ue.eventId)
+    matchingEvent.userId = ue.userId
+    matchingEvent.creator = ue.creator
+    return matchingEvent
+  })
+
+  if (filteredEvents.includes(undefined) === false){
+    return (
+      <>
+      <Link to="/events/create">
+      <button className="btn--addEvent">Add Event</button>
+      </Link>
+      <div className="events">
+        {
+          filteredEvents.map(event => {
+            return <EventsCard key={event.id} event={event} />
+          })
+        }
+      </div>
+      </>
+    )
+  } else {
+    return <></>
+  }
 }


### PR DESCRIPTION
# Description

user can see friends' events and friends' events are stylized differently than user's

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

create event objects with corresponding userEvent objects with user ID's in database.
event list should only view the user's and their friends' events.
events should only show edit button if event belongs to the user.
friends' events should be have a different background color and italicized text.

`git fetch --all`
`git checkout pp-friends-friendsEvents`
`npm start`

In another tab, cd into `api` and run

`json-server -p 8088 -w database.json`

# Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings or errors
- [ x] I have added test instructions that prove my fix is effective or that my feature works

	
