### PR TITLE
Jhf messages real time

### DIFF
--- a/src/components/messages/MessageForm.jsx
+++ b/src/components/messages/MessageForm.jsx
@@ -86,6 +86,7 @@ export const MessageForm = () => {
         window.alert("Message Sent")
       }).then(history.push("/messages"))
     }
+    localStorage.setItem("messageChange", false)
       
 
   } // handleSendMessage

--- a/src/components/messages/MessageList.jsx
+++ b/src/components/messages/MessageList.jsx
@@ -13,16 +13,16 @@ import { MessageForm } from "./MessageForm"
 
 
 export const MessageList = () => {
-
  const { messages, getMessages } = useContext(MessageContext)
  const { users, getUsers } = useContext(UsersContext)
  const currentUserId = parseInt(sessionStorage.getItem("nutshell_user"))
 
  useEffect(() => {
   getMessages().then(getUsers)
- }, [messages]) // useEffect
-
-
+ }, [])
+ window.onstorage = (e) => {
+   getMessages()
+ }
  const filteredReceived = messages.filter(message => message.curentUserId === currentUserId)
  const filteredSent = messages.filter(message => message.userId === currentUserId)
  filteredSent.forEach(message => message.canEdit = true)

--- a/src/components/messages/MessageProvider.jsx
+++ b/src/components/messages/MessageProvider.jsx
@@ -2,7 +2,7 @@
  @author - cheo
  @return MessageContext.Provider with methods to manipulate messages data.
 */
-import React, { createContext, useState } from "react" 
+import React, { createContext, useEffect, useState } from "react" 
 
 export const MessageContext = createContext()
 
@@ -22,13 +22,15 @@ export const MessageProvider = ( props ) => {
    if ( Date.parse(nextDate.timestamp) > Date.parse(currDate.timestamp) ) { return 1; }
    return 0;
  } // _byDate
- 
 
  const getMessages = () => {
   return fetch("http://localhost:8088/messages?_expand=user")
    .then(res => res.json())
    .then(data => data.sort(_byDate))
    .then(setMessages)
+   .then(() => {
+     localStorage.setItem("messageChange", true)
+    console.log("get messages")})
  } // getMessages
 
 


### PR DESCRIPTION
# Description
made real time messaging by adding a window.onstorage listener and a local storage item changeMessage that will change when the messages are updated
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions

Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests

`git fetch --all`
`git checkout <branch-name>`
`npm start`

In another tab, cd into `api` and run

`json-server -p 8088 -w database.json`

run two tabs signed in as different users send a message from one to the other and should show up in both tabs without a refresh
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works

	
